### PR TITLE
Improve the export task dsl

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,14 @@ plugins {
 
 structurizrCli {
     version = "1.3.1"
-    export = [
-        "plantuml": ["docs/diagrams/workspace.dsl"]
-    ]
+    export {
+        format = "plantuml"
+        workspace = "docs/diagrams/workspace.dsl"
+    }
+    export {
+        format = "json"
+        workspace = "docs/diagrams/workspace.dsl"
+    }
 }
 ```
 
@@ -29,9 +34,14 @@ plugins {
 
 structurizrCli {
     version = "1.3.1"
-    export = mapOf(
-        "plantuml" to listOf("docs/diagrams/mastermind.dsl")
-    )
+    export {
+        format = "plantuml"
+        workspace = "docs/diagrams/workspace.dsl"
+    }
+    export {
+        format = "json"
+        workspace = "docs/diagrams/workspace.dsl"
+    }
 }
 ```
 

--- a/src/functionalTest/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPluginFunctionalTest.kt
+++ b/src/functionalTest/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPluginFunctionalTest.kt
@@ -77,7 +77,10 @@ class StructurizrCliPluginFunctionalTest {
             }
             structurizrCli {
                 version = "1.3.1"
-                export = ["plantuml": ["${projectDir.absolutePath}/workspace.dsl"]]
+                export {
+                    format = "plantuml"
+                    workspace = "${projectDir.absolutePath}/workspace.dsl"
+                }
             }
         """)
 

--- a/src/main/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPlugin.kt
+++ b/src/main/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPlugin.kt
@@ -61,15 +61,12 @@ class StructurizrCliPlugin : Plugin<Project> {
         }
         project.afterEvaluate {
             // export tasks need to be created once configuration has been processed
-            extension.export.flatMap { export ->
-                val format = export.key
-                export.value.mapIndexed { index, workspace ->
-                    project.tasks.register("structurizrCliExport-$format$index", JavaExec::class.java) { task ->
-                        task.dependsOn("structurizrCliExtract")
-                        task.workingDir(project.projectDir)
-                        task.classpath(project.files(structurizrCliJar(project, extension)))
-                        task.args("export", "-workspace", workspace, "-format", format)
-                    }
+            extension.exports.forEachIndexed { index, export ->
+                project.tasks.register("structurizrCliExport-${export.format}$index", JavaExec::class.java) { task ->
+                    task.dependsOn("structurizrCliExtract")
+                    task.workingDir(project.projectDir)
+                    task.classpath(project.files(structurizrCliJar(project, extension)))
+                    task.args("export", "-workspace", export.workspace, "-format", export.format)
                 }
             }
         }

--- a/src/main/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPluginExtension.kt
+++ b/src/main/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPluginExtension.kt
@@ -1,6 +1,18 @@
 package pl.zalas.gradle.structurizrcli
 
+import org.gradle.api.Action
+
 open class StructurizrCliPluginExtension {
     var version: String? = "1.3.1"
-    var export: Map<String, List<String>> = emptyMap()
+    var exports: List<Export> = emptyList()
+        private set
+
+    fun export(action: Action<Export>) {
+        Export().let { export ->
+            action.execute(export)
+            exports = exports + export
+        }
+    }
+
+    data class Export(var format: String = "plantuml", var workspace: String = "workspace.dsl")
 }


### PR DESCRIPTION
Instead of:

```groovy
structurizrCli {
    export = [
        "plantuml": ["docs/diagrams/workspace.dsl"]
   ]
}
```

use the more explicit:

```groovy
structurizrCli {
    export {
        format = "plantuml"
        workspace = "docs/diagrams/workspace.dsl"
    }
}
```