### PR TITLE
Drop the redundant gradle from plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Enables Gradle to run [Structurizr CLI](https://github.com/structurizr/cli) comm
 
 ```groovy
 plugins {
-    id('pl.zalas.gradle.structurizrcli') version '1.0.0'
+    id('pl.zalas.structurizr-cli') version '1.0.0'
 }
 
 structurizrCli {
@@ -29,7 +29,7 @@ structurizrCli {
 
 ```kotlin
 plugins {
-    id("pl.zalas.gradle.structurizrcli") version "1.0.0"
+    id("pl.zalas.structurizr-cli") version "1.0.0"
 }
 
 structurizrCli {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,8 @@ dependencies {
 
 gradlePlugin {
     val structurizrcli by plugins.creating {
-        id = "pl.zalas.gradle.structurizrcli"
+        id = "pl.zalas.structurizr-cli"
+        displayName = "gradle-structurizr-cli"
         implementationClass = "pl.zalas.gradle.structurizrcli.StructurizrCliPlugin"
         description = "Enables Gradle to run Structurizr CLI commands."
     }

--- a/src/functionalTest/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPluginFunctionalTest.kt
+++ b/src/functionalTest/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPluginFunctionalTest.kt
@@ -27,7 +27,7 @@ class StructurizrCliPluginFunctionalTest {
     fun `it downloads structurizr cli`(@TempDir projectDir: File) {
         givenConfiguration(projectDir, """
             plugins {
-                id('pl.zalas.gradle.structurizrcli')
+                id('pl.zalas.structurizr-cli')
             }
         """)
 
@@ -40,7 +40,7 @@ class StructurizrCliPluginFunctionalTest {
     fun `it downloads structurizr cli in the configured version`(@TempDir projectDir: File) {
         givenConfiguration(projectDir, """
             plugins {
-                id('pl.zalas.gradle.structurizrcli')
+                id('pl.zalas.structurizr-cli')
             }
             structurizrCli {
                 version = "1.3.0"
@@ -56,7 +56,7 @@ class StructurizrCliPluginFunctionalTest {
     fun `it extracts the downloaded structurizr cli`(@TempDir projectDir: File) {
         givenConfiguration(projectDir, """
             plugins {
-                id('pl.zalas.gradle.structurizrcli')
+                id('pl.zalas.structurizr-cli')
             }
             structurizrCli {
                 version = "1.3.1"
@@ -73,7 +73,7 @@ class StructurizrCliPluginFunctionalTest {
         givenWorkspace(projectDir, "workspace.dsl")
         givenConfiguration(projectDir, """
             plugins {
-                id('pl.zalas.gradle.structurizrcli')
+                id('pl.zalas.structurizr-cli')
             }
             structurizrCli {
                 version = "1.3.1"

--- a/src/test/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPluginTest.kt
+++ b/src/test/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPluginTest.kt
@@ -23,7 +23,7 @@ class StructurizrCliPluginTest {
     @Test
     fun `it registers the structurizrCliDownload task`() {
         val project = ProjectBuilder.builder().build()
-        project.plugins.apply("pl.zalas.gradle.structurizrcli")
+        project.plugins.apply("pl.zalas.structurizr-cli")
 
         assertNotNull(project.tasks.findByName("structurizrCliDownload"))
     }
@@ -31,7 +31,7 @@ class StructurizrCliPluginTest {
     @Test
     fun `it registers the structurizrCliExtract task`() {
         val project = ProjectBuilder.builder().build()
-        project.plugins.apply("pl.zalas.gradle.structurizrcli")
+        project.plugins.apply("pl.zalas.structurizr-cli")
 
         assertNotNull(project.tasks.findByName("structurizrCliExtract"))
     }
@@ -39,7 +39,7 @@ class StructurizrCliPluginTest {
     @Test
     fun `it registers the structurizrCliExport task`() {
         val project = ProjectBuilder.builder().build()
-        project.plugins.apply("pl.zalas.gradle.structurizrcli")
+        project.plugins.apply("pl.zalas.structurizr-cli")
 
         assertNotNull(project.tasks.findByName("structurizrCliExport"))
     }


### PR DESCRIPTION
<!--
Please read the CONTRIBUTING.md to learn about contributing to this project.

Please also note that this project is released with a Contributor Code of Conduct.
By participating in this project you agree to abide by its terms.
The Code of Conduct can be found in CODE_OF_CONDUCT.md.
-->

