### PR TITLE
Fix auto-naming and add custom naming option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ structurizrCli {
         format = "json"
         workspace = "docs/diagrams/workspace.dsl"
     }
+    export {
+        format = "plantuml"
+        workspace = "docs/diagrams/workspace2.dsl"
+        name = "SomeCustomName"
+    }
 }
 ```
 

--- a/src/functionalTest/kotlin/pl/zalas/gradle/structurizrcli/ExportWithCustomNameFunctionalTest.kt
+++ b/src/functionalTest/kotlin/pl/zalas/gradle/structurizrcli/ExportWithCustomNameFunctionalTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Jakub Zalas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pl.zalas.gradle.structurizrcli
+
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ExportWithCustomNameFunctionalTest : FunctionalTest {
+
+    @Test
+    fun `it exports the workspace with custom name`(@TempDir projectDir: File) {
+        givenWorkspace(projectDir, "workspace.dsl")
+        givenConfiguration(projectDir, """
+            plugins {
+                id 'pl.zalas.structurizr-cli'
+            }
+            structurizrCli {
+                export {
+                    format = "plantuml"
+                    workspace = "${projectDir.absolutePath}/workspace.dsl"
+                    name = "myCustomName"
+                }
+            }
+        """)
+
+        execute(projectDir, "structurizrCliExport-myCustomName")
+
+        assertTrue(File("${projectDir.absolutePath}/structurizr-SystemContext.puml").exists())
+    }
+}

--- a/src/main/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPlugin.kt
+++ b/src/main/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPlugin.kt
@@ -63,7 +63,8 @@ class StructurizrCliPlugin : Plugin<Project> {
         afterEvaluate {
             // export tasks need to be created once configuration has been processed
             extension.exports.forEachIndexed { index, export ->
-                tasks.register("structurizrCliExport-${export.format}$index", Export::class.java) { task ->
+                export.name = export.name.ifEmpty { export.format.replace("/", "-") + index }
+                tasks.register("structurizrCliExport-${export.name}", Export::class.java) { task ->
                     task.dependsOn("structurizrCliExtract")
                     task.workspace.set(layout.projectDirectory.file(export.workspace))
                     task.format.set(export.format)

--- a/src/main/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPluginExtension.kt
+++ b/src/main/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPluginExtension.kt
@@ -29,5 +29,9 @@ open class StructurizrCliPluginExtension {
         }
     }
 
-    data class Export(var format: String = "plantuml", var workspace: String = "workspace.dsl")
+    data class Export(
+        var format: String = "plantuml", 
+        var workspace: String = "workspace.dsl",
+        var name: String = ""
+        )
 }

--- a/src/test/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPluginTest.kt
+++ b/src/test/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPluginTest.kt
@@ -15,11 +15,16 @@
  */
 package pl.zalas.gradle.structurizrcli
 
+
+import org.gradle.api.internal.project.ProjectInternal
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
 import org.gradle.testfixtures.ProjectBuilder
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 
 class StructurizrCliPluginTest {
+
     @Test
     fun `it registers the structurizrCliVersion task`() {
         val project = ProjectBuilder.builder().build()
@@ -50,6 +55,38 @@ class StructurizrCliPluginTest {
         project.plugins.apply("pl.zalas.structurizr-cli")
 
         assertNotNull(project.tasks.findByName("structurizrCliExport"))
+    }
+
+    @Test
+    fun `it registers a defined structurizrCliExport task with default name`(@TempDir projectDir: File) {
+        projectDir.resolve("build.gradle").writeText("""
+            structurizrCli {
+                export {
+                    format = "plantuml/c4plantuml"
+                }
+            }
+        """.trimIndent())
+        val project = ProjectBuilder.builder().withProjectDir(projectDir).build() as ProjectInternal
+        project.plugins.apply("pl.zalas.structurizr-cli")
+        project.evaluate()
+
+        assertNotNull(project.tasks.findByName("structurizrCliExport-plantuml-c4plantuml0"))
+    }
+
+    @Test
+    fun `it registers a defined structurizrCliExport task with custom name`(@TempDir projectDir: File) {
+        projectDir.resolve("build.gradle").writeText("""
+            structurizrCli {
+                export {
+                    name = "myName"
+                }
+            }
+        """.trimIndent())
+        val project = ProjectBuilder.builder().withProjectDir(projectDir).build() as ProjectInternal
+        project.plugins.apply("pl.zalas.structurizr-cli")
+        project.evaluate()
+
+        assertNotNull(project.tasks.findByName("structurizrCliExport-myName"))
     }
 
     @Test


### PR DESCRIPTION
Hi Jakzal, I found a little bug and added a small features. Best Andreas

* structurizr-cli offer formats containing '/', which is not an allowed
character for gradle-tasks
* custom names allow stable jobnames, even when changing the
configuration (format, order)

<!--
Please read the CONTRIBUTING.md to learn about contributing to this project.

Please also note that this project is released with a Contributor Code of Conduct.
By participating in this project you agree to abide by its terms.
The Code of Conduct can be found in CODE_OF_CONDUCT.md.
-->

