### PR TITLE
Make the downloads and structurizr-cli directories configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,39 @@ Pushes content to a Structurizr workspace.
     --secret 453a265d-099e-491c-89b5-41945395bcfb
     --workspace workspace.dsl
 ```
+
+### Download
+
+```bash
+./gradlew structurizrCliDownload
+```
+
+By default, the structurizr-cli zip is downloaded to the `build/downloads` directory.
+
+It can be customised in relation to the project directory:
+
+```kotlin
+structurizrCli {
+    download {
+        directory = "downloads"
+    }
+}
+```
+
+### Extract
+
+```bash
+./gradlew structurizrCliExtract
+```
+
+By default, the structurizr-cli zip is extracted to the `build/structurizr-cli` directory.
+
+It can be customised in relation to the project directory:
+
+```kotlin
+structurizrCli {
+    extract {
+        directory = "structurizr-cli"
+    }
+}
+```

--- a/src/functionalTest/kotlin/pl/zalas/gradle/structurizrcli/DownloadFunctionalTest.kt
+++ b/src/functionalTest/kotlin/pl/zalas/gradle/structurizrcli/DownloadFunctionalTest.kt
@@ -37,4 +37,23 @@ class DownloadFunctionalTest : FunctionalTest {
 
         assertTrue(File("${projectDir.absolutePath}/build/downloads/structurizr-cli-1.13.0.zip").exists())
     }
+
+    @Test
+    fun `it downloads structurizr cli to a custom downloads directory`(@TempDir projectDir: File) {
+        givenConfiguration(projectDir, """
+            plugins {
+                id 'pl.zalas.structurizr-cli'
+            }
+            structurizrCli {
+                version = "1.19.0"
+                download {
+                    directory = "downloads"
+                }
+            }
+        """)
+
+        execute(projectDir, "structurizrCliDownload")
+
+        assertTrue(File("${projectDir.absolutePath}/downloads/structurizr-cli-1.19.0.zip").exists())
+    }
 }

--- a/src/functionalTest/kotlin/pl/zalas/gradle/structurizrcli/ExtractFunctionalTest.kt
+++ b/src/functionalTest/kotlin/pl/zalas/gradle/structurizrcli/ExtractFunctionalTest.kt
@@ -37,4 +37,23 @@ class ExtractFunctionalTest : FunctionalTest {
 
         assertTrue(File("${projectDir.absolutePath}/build/structurizr-cli/lib/structurizr-cli-1.13.0.jar").exists())
     }
+
+    @Test
+    fun `it extracts the downloaded structurizr cli to a custom directory`(@TempDir projectDir: File) {
+        givenConfiguration(projectDir, """
+            plugins {
+                id 'pl.zalas.structurizr-cli'
+            }
+            structurizrCli {
+                version = "1.19.0"
+                extract {
+                    directory = "structurizr-cli"
+                }
+            }
+        """)
+
+        execute(projectDir, "structurizrCliExtract")
+
+        assertTrue(File("${projectDir.absolutePath}/structurizr-cli/lib/structurizr-cli-1.19.0.jar").exists())
+    }
 }

--- a/src/main/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPluginExtension.kt
+++ b/src/main/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPluginExtension.kt
@@ -21,6 +21,8 @@ open class StructurizrCliPluginExtension {
     var version: String? = null
     var exports: List<Export> = emptyList()
         private set
+    var download: Download = Download()
+    var extract: Extract = Extract()
 
     fun export(action: Action<Export>) {
         Export().let { export ->
@@ -29,9 +31,31 @@ open class StructurizrCliPluginExtension {
         }
     }
 
+    fun download(action: Action<Download>) {
+        Download().let { d ->
+            action.execute(d)
+            download = d
+        }
+    }
+
+    fun extract(action: Action<Extract>) {
+        Extract().let { e ->
+            action.execute(e)
+            extract = e
+        }
+    }
+
     data class Export(
-        var format: String = "plantuml", 
+        var format: String = "plantuml",
         var workspace: String = "workspace.dsl",
         var name: String = ""
-        )
+    )
+
+    data class Download(
+        var directory: String? = null
+    )
+
+    data class Extract(
+        var directory: String? = null
+    )
 }


### PR DESCRIPTION
Fixes #65

Makes it possible to configure the downloads and structurizr-cli directories (relative to the project dir):

```kotlin
plugins {
    id("pl.zalas.structurizr-cli") version "1.3.0"
}

structurizrCli {
    download {
        directory = "downloads"
    }
    extract {
        directory = "structurizr-cli"
    }
}
```
