### PR TITLE
Switch to Java 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,10 @@ jobs:
                 sed -i'' -e "/^version=/s/=.*/=$BUILD_VERSION/" gradle.properties
                 echo $BUILD_VERSION
                 echo "BUILD_VERSION=$BUILD_VERSION" >> $GITHUB_ENV
-            - name: Set up JDK 1.8
+            - name: Set up JDK 11
               uses: actions/setup-java@v3
               with:
-                java-version: 8
+                java-version: 11
                 distribution: 'zulu'
             - name: Configure gradle ${{ matrix.gradle-version }}
               run: sed -i.bkp -e 's/\(distributionUrl=.*gradle\)-[0-9]*\.[0-9]*\(\.[0-9]*\)\{0,1\}\(.*\)/\1-${{ matrix.gradle-version }}\3/' gradle/wrapper/gradle-wrapper.properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,17 +10,17 @@ plugins {
 
 group = "pl.zalas"
 
-java.sourceCompatibility = JavaVersion.VERSION_1_8
-java.targetCompatibility = JavaVersion.VERSION_1_8
+java.sourceCompatibility = JavaVersion.VERSION_11
+java.targetCompatibility = JavaVersion.VERSION_11
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 
 idea {
     project {
-        jdkName = "1.8"
-        languageLevel = IdeaLanguageLevel("1.8")
+        jdkName = "11"
+        languageLevel = IdeaLanguageLevel("11")
     }
 }
 


### PR DESCRIPTION
Seems that structurizr has changed the Java version they build against since tests are now failing with:

```
> Task :structurizrCliExport-plantuml0 FAILED
Error: A JNI error has occurred, please check your installation and try again
Exception in thread "main" java.lang.UnsupportedClassVersionError: com/structurizr/cli/StructurizrCliApplication has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:757)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:473)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
	at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:601)
```