### PR TITLE
Run export tasks sequentially for more predictability

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/functionalTest/kotlin/pl/zalas/gradle/structurizrcli/ExportFunctionalTest.kt
+++ b/src/functionalTest/kotlin/pl/zalas/gradle/structurizrcli/ExportFunctionalTest.kt
@@ -41,4 +41,40 @@ class ExportFunctionalTest : FunctionalTest {
 
         assertTrue(File("${projectDir.absolutePath}/structurizr-SystemContext.puml").exists())
     }
+
+    @Test
+    fun `it exports multiple workspaces`(@TempDir projectDir: File, @TempDir workspaceDir1: File, @TempDir workspaceDir2: File) {
+        givenWorkspace(workspaceDir1, "workspace1.dsl")
+        givenWorkspace(workspaceDir2, "workspace2.dsl")
+        givenConfiguration(projectDir, """
+            plugins {
+                id 'pl.zalas.structurizr-cli'
+            }
+            structurizrCli {
+                export {
+                    format = "plantuml"
+                    workspace = "${workspaceDir1.absolutePath}/workspace1.dsl"
+                }
+                export {
+                    format = "plantuml"
+                    workspace = "${workspaceDir2.absolutePath}/workspace2.dsl"
+                }
+                export {
+                    format = "json"
+                    workspace = "${workspaceDir1.absolutePath}/workspace1.dsl"
+                }
+                export {
+                    format = "json"
+                    workspace = "${workspaceDir2.absolutePath}/workspace2.dsl"
+                }
+            }
+        """)
+
+        execute(projectDir, "structurizrCliExport")
+
+        assertTrue(File("${workspaceDir1.absolutePath}/structurizr-SystemContext.puml").exists())
+        assertTrue(File("${workspaceDir2.absolutePath}/structurizr-SystemContext.puml").exists())
+        assertTrue(File("${workspaceDir1.absolutePath}/workspace1.json").exists())
+        assertTrue(File("${workspaceDir2.absolutePath}/workspace2.json").exists())
+    }
 }

--- a/src/main/kotlin/pl/zalas/gradle/structurizrcli/tasks/Export.kt
+++ b/src/main/kotlin/pl/zalas/gradle/structurizrcli/tasks/Export.kt
@@ -47,7 +47,7 @@ open class Export : DefaultTask() {
     fun export() {
         project.javaexec { spec ->
             spec.workingDir(project.layout.projectDirectory)
-            spec.classpath(structurizrCliJar.get(), structurizrCliDirectory.dir("lib/*"))
+            spec.classpath(structurizrCliDirectory.dir("lib/*"))
             spec.mainClass.set("com.structurizr.cli.StructurizrCliApplication")
             spec.args("export", "-workspace", workspace.get(), "-format", format.get())
         }


### PR DESCRIPTION
Fixes https://github.com/jakzal/gradle-structurizr-cli/issues/89

Without the tasks run in sequence, the following error is reported by Gradle >= 7.0:

```
Task ':structurizrCliExport-plantuml0' uses this output of task ':structurizrCliExport-plantuml1' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed
```

<!--
Please read the CONTRIBUTING.md to learn about contributing to this project.

Please also note that this project is released with a Contributor Code of Conduct.
By participating in this project you agree to abide by its terms.
The Code of Conduct can be found in CODE_OF_CONDUCT.md.
-->

