### PR TITLE
Upgrade to Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,10 @@ jobs:
                 sed -i'' -e "/^version=/s/=.*/=$BUILD_VERSION/" gradle.properties
                 echo $BUILD_VERSION
                 echo "BUILD_VERSION=$BUILD_VERSION" >> $GITHUB_ENV
-            - name: Set up JDK 11
+            - name: Set up JDK 17
               uses: actions/setup-java@v3
               with:
-                java-version: 11
+                java-version: 17
                 distribution: 'zulu'
             - name: Configure gradle ${{ matrix.gradle-version }}
               run: sed -i.bkp -e 's/\(distributionUrl=.*gradle\)-[0-9]*\.[0-9]*\(\.[0-9]*\)\{0,1\}\(.*\)/\1-${{ matrix.gradle-version }}\3/' gradle/wrapper/gradle-wrapper.properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,17 +10,17 @@ plugins {
 
 group = "pl.zalas"
 
-java.sourceCompatibility = JavaVersion.VERSION_11
-java.targetCompatibility = JavaVersion.VERSION_11
+java.sourceCompatibility = JavaVersion.VERSION_17
+java.targetCompatibility = JavaVersion.VERSION_17
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions.jvmTarget = "11"
+    kotlinOptions.jvmTarget = "17"
 }
 
 idea {
     project {
-        jdkName = "11"
-        languageLevel = IdeaLanguageLevel("11")
+        jdkName = "17"
+        languageLevel = IdeaLanguageLevel("17")
     }
 }
 


### PR DESCRIPTION
I had some issues running this plugin with JDK 17, but since the structurizr-cli also depends on 17, I think it would make sense to align these versions.
