### PR TITLE
Add the "v" prefix back to the version in the download URL

### DIFF
--- a/src/functionalTest/kotlin/pl/zalas/gradle/structurizrcli/DownloadFunctionalTest.kt
+++ b/src/functionalTest/kotlin/pl/zalas/gradle/structurizrcli/DownloadFunctionalTest.kt
@@ -30,13 +30,13 @@ class DownloadFunctionalTest : FunctionalTest {
                 id 'pl.zalas.structurizr-cli'
             }
             structurizrCli {
-                version = "2024.01.02"
+                version = "2024.02.22"
             }
         """)
 
         execute(projectDir, "structurizrCliDownload")
 
-        assertTrue(File("${projectDir.absolutePath}/build/downloads/structurizr-cli-2024.01.02.zip").exists())
+        assertTrue(File("${projectDir.absolutePath}/build/downloads/structurizr-cli-2024.02.22.zip").exists())
     }
 
     @Test
@@ -46,7 +46,7 @@ class DownloadFunctionalTest : FunctionalTest {
                 id 'pl.zalas.structurizr-cli'
             }
             structurizrCli {
-                version = "2024.01.02"
+                version = "2024.02.22"
                 download {
                     directory = "tmp"
                 }
@@ -55,7 +55,7 @@ class DownloadFunctionalTest : FunctionalTest {
 
         execute(projectDir, "structurizrCliDownload")
 
-        assertTrue(File("${projectDir.absolutePath}/tmp/structurizr-cli-2024.01.02.zip").exists())
+        assertTrue(File("${projectDir.absolutePath}/tmp/structurizr-cli-2024.02.22.zip").exists())
     }
 
     @Test

--- a/src/functionalTest/kotlin/pl/zalas/gradle/structurizrcli/ExtractFunctionalTest.kt
+++ b/src/functionalTest/kotlin/pl/zalas/gradle/structurizrcli/ExtractFunctionalTest.kt
@@ -29,7 +29,7 @@ class ExtractFunctionalTest : FunctionalTest {
                 id 'pl.zalas.structurizr-cli'
             }
             structurizrCli {
-                version = "2024.01.02"
+                version = "2024.02.22"
             }
         """)
 
@@ -61,7 +61,7 @@ class ExtractFunctionalTest : FunctionalTest {
                 id 'pl.zalas.structurizr-cli'
             }
             structurizrCli {
-                version = "2024.01.02"
+                version = "2024.02.22"
                 extract {
                     directory = "structurizr-cli"
                 }

--- a/src/main/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPlugin.kt
+++ b/src/main/kotlin/pl/zalas/gradle/structurizrcli/StructurizrCliPlugin.kt
@@ -42,7 +42,7 @@ class StructurizrCliPlugin : Plugin<Project> {
             tasks.register("structurizrCliDownload", Download::class.java) { task ->
                 task.version.set(version.flatMap { it.version })
                 task.downloadDirectory.set(downloadsDirectory(extension))
-                task.downloadUrlTemplate.set("https://github.com/structurizr/cli/releases/download/{VERSION}/structurizr-cli.zip")
+                task.downloadUrlTemplate.set("https://github.com/structurizr/cli/releases/download/v{VERSION}/structurizr-cli.zip")
                 task.legacyDownloadUrlTemplate.set("https://github.com/structurizr/cli/releases/download/v{VERSION}/structurizr-cli-{VERSION}.zip")
             }
 

--- a/src/main/kotlin/pl/zalas/gradle/structurizrcli/tasks/Download.kt
+++ b/src/main/kotlin/pl/zalas/gradle/structurizrcli/tasks/Download.kt
@@ -32,7 +32,7 @@ open class Download : DefaultTask() {
     @Input
     val version: Property<String> = project.objects.property(String::class.java)
 
-    // Example: https://github.com/structurizr/cli/releases/download/2024.01.02/structurizr-cli.zip
+    // Example: https://github.com/structurizr/cli/releases/download/v2024.01.02/structurizr-cli.zip
     @Input
     val downloadUrlTemplate: Property<String> = project.objects.property(String::class.java)
 


### PR DESCRIPTION
The latest release includes the "v" prefix again.
