### PR TITLE
Replace deprecated calls

### DIFF
--- a/src/main/kotlin/pl/zalas/gradle/structurizrcli/tasks/Export.kt
+++ b/src/main/kotlin/pl/zalas/gradle/structurizrcli/tasks/Export.kt
@@ -19,13 +19,11 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.*
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
 
-open class Export : DefaultTask() {
+open class Export @Inject constructor(@Internal val execOperations: ExecOperations) : DefaultTask() {
 
     @InputFile
     val workspace: RegularFileProperty = project.objects.fileProperty()
@@ -50,7 +48,7 @@ open class Export : DefaultTask() {
 
     @TaskAction
     fun export() {
-        project.javaexec { spec ->
+        execOperations.javaexec { spec ->
             spec.workingDir(project.layout.projectDirectory)
             spec.classpath(structurizrCliDirectory.dir("lib/*"))
             spec.mainClass.set("com.structurizr.cli.StructurizrCliApplication")

--- a/src/main/kotlin/pl/zalas/gradle/structurizrcli/tasks/Pull.kt
+++ b/src/main/kotlin/pl/zalas/gradle/structurizrcli/tasks/Pull.kt
@@ -6,8 +6,10 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.options.Option
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
 
-open class Pull : DefaultTask() {
+open class Pull @Inject constructor(@Internal val execOperations: ExecOperations) : DefaultTask() {
 
     @InputFile
     val structurizrCliJar: RegularFileProperty = project.objects.fileProperty()
@@ -50,7 +52,7 @@ open class Pull : DefaultTask() {
 
     @TaskAction
     fun pull() {
-        project.javaexec { spec ->
+        execOperations.javaexec { spec ->
             spec.workingDir(project.layout.projectDirectory)
             spec.classpath(structurizrCliJar.get(), structurizrCliDirectory.dir("lib/*"))
             spec.mainClass.set("com.structurizr.cli.StructurizrCliApplication")

--- a/src/main/kotlin/pl/zalas/gradle/structurizrcli/tasks/Push.kt
+++ b/src/main/kotlin/pl/zalas/gradle/structurizrcli/tasks/Push.kt
@@ -6,8 +6,10 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.options.Option
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
 
-open class Push : DefaultTask() {
+open class Push @Inject constructor(@Internal val execOperations: ExecOperations) : DefaultTask() {
 
     @InputFile
     val structurizrCliJar: RegularFileProperty = project.objects.fileProperty()
@@ -86,7 +88,7 @@ open class Push : DefaultTask() {
 
     @TaskAction
     fun push() {
-        project.javaexec { spec ->
+        execOperations.javaexec { spec ->
             spec.workingDir(project.layout.projectDirectory)
             spec.classpath(structurizrCliJar.get(), structurizrCliDirectory.dir("lib/*"))
             spec.mainClass.set("com.structurizr.cli.StructurizrCliApplication")

--- a/src/main/kotlin/pl/zalas/gradle/structurizrcli/tasks/Version.kt
+++ b/src/main/kotlin/pl/zalas/gradle/structurizrcli/tasks/Version.kt
@@ -20,7 +20,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
-import java.net.URL
+import java.net.URI
 
 open class Version : DefaultTask() {
 
@@ -38,7 +38,8 @@ open class Version : DefaultTask() {
 
     private fun latestVersionProvider(): Provider<String> = project.provider(this::latestVersion)
 
-    private fun latestVersion(): String = URL("https://api.github.com/repos/structurizr/cli/releases/latest")
+    private fun latestVersion(): String = URI.create("https://api.github.com/repos/structurizr/cli/releases/latest")
+            .toURL()
             .readText()
             .replace("(?smi).*?\"tag_name\":\\s*\"v?([0-9.]*)\".*".toRegex(), "$1")
 }


### PR DESCRIPTION
* Replace `project.javaexec` calls with `ExecOperations.javaexec` (see https://github.com/gradle/gradle/issues/30822)
* Replace the use of `URL()` constructor with `URI.create().toURL()`